### PR TITLE
Adding non-reified version of API methods.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ On app-level `build.gradle`, add dependency:
 
 ```groovy
 dependencies {
-    implementation 'com.github.psteiger:geofire-ktx:0.3'
+    implementation 'com.github.psteiger:geofire-ktx:0.4'
 }
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath "com.android.tools.build:gradle:7.0.0-alpha02"
+        classpath 'com.android.tools.build:gradle:7.0.0-alpha05'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/geofire/src/main/java/com/freelapp/geofire/Api.kt
+++ b/geofire/src/main/java/com/freelapp/geofire/Api.kt
@@ -59,3 +59,19 @@ fun GeoQuery.asFlow(
 inline fun <reified T : Any> GeoQuery.asTypedFlow(
     dataRef: String
 ): Flow<Map<Key, LocationData<T>>> = asTypedFlowImpl(dataRef)
+
+/**
+ * Transforms a [GeoQuery] into a cold [Flow] of maps between [GeoQuery] keys and corresponding
+ * [LocationData] objects, which contain the [GeoLocation] and an object of type [T] (the object
+ * obtained by converting the [DataSnapshot] stored in "[dataRef]/$key" to an object of type [T]).
+ * <p>
+ * If conversion of the [DataSnapshot] to an object of type [T] fails, [LocationData]'s data will be
+ * null.
+ *
+ * @return a flow of a mapping between the key and the [LocationData].
+ */
+@ExperimentalCoroutinesApi
+fun <T : Any> GeoQuery.asTypedFlow(
+    clazz: Class<T>,
+    dataRef: String
+): Flow<Map<Key, LocationData<T>>> = asTypedFlowImpl(clazz, dataRef)

--- a/geofire/src/main/java/com/freelapp/geofire/flow/GeoQuery.kt
+++ b/geofire/src/main/java/com/freelapp/geofire/flow/GeoQuery.kt
@@ -64,3 +64,18 @@ internal inline fun <reified T : Any> GeoQuery.asTypedFlowImpl(
                 }
             }
         }
+
+@PublishedApi
+@ExperimentalCoroutinesApi
+internal fun <T : Any> GeoQuery.asTypedFlowImpl(
+    clazz: Class<T>,
+    dataRef: String
+): Flow<Map<Key, LocationData<T>>> =
+    asFlowImpl(dataRef)
+        .mapLatest { map ->
+            map.mapValues {
+                it.value.run {
+                    LocationData(location, data.getTypedValue(clazz))
+                }
+            }
+        }

--- a/geofire/src/main/java/com/freelapp/geofire/util/Util.kt
+++ b/geofire/src/main/java/com/freelapp/geofire/util/Util.kt
@@ -12,3 +12,7 @@ internal fun <E> SendChannel<E>.tryOffer(element: E): Boolean =
 @PublishedApi
 internal inline fun <reified T : Any> DataSnapshot.getTypedValue(): T? =
     getValue(object : GenericTypeIndicator<T>() {})
+
+@PublishedApi
+internal fun <T : Any> DataSnapshot.getTypedValue(clazz: Class<T>): T? =
+    getValue(clazz)

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Wed Dec 09 17:51:17 BRT 2020
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
+distributionUrl=https://services.gradle.org/distributions/gradle-6.8-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
When type parameters come from a class generics, using
reified parameters in inline functions is not possible.