### PR TITLE
Add maven-publish plugin

### DIFF
--- a/geofire/build.gradle
+++ b/geofire/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id 'com.android.library'
     id 'kotlin-android'
+    id 'maven-publish'
 }
 
 android {
@@ -19,6 +20,18 @@ android {
 
     kotlinOptions {
         jvmTarget = '1.8'
+    }
+}
+
+afterEvaluate {
+    publishing {
+        publications {
+            // Creates a Maven publication called "release".
+            release(MavenPublication) {
+                from components.release
+                artifactId = "$project.name"
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Android maven is no more, as Gradle supports maven directly.